### PR TITLE
Add repository deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+# ⛔️ REPOSITORY DEPRECATED
+
+This repository is no longer being used for this package as of [version 1.8.20](https://community.chocolatey.org/packages/LiveSplit/1.8.20), and exists only for archival purposes.
+
+Issues and pull requests should not be submitted here.
+
+This package is now being maintained at [brogers5/chocolatey-package-livesplit](https://github.com/brogers5/chocolatey-package-livesplit).
+
+---
+
 Chocolatey package for LiveSplit


### PR DESCRIPTION
I tried reaching out to you a few weeks ago via the Contact Maintainers link on the Community Repository's package page. Since I never heard back, I pursued the Package Triage Process and have since become a co-maintainer of the LiveSplit package. In order to move forward with publishing a new version to the Chocolatey Community Repository, I had to create a new repository where I had direct write access.

Because [no license](https://choosealicense.com/no-permission/) was defined for this repository, I opted to rewrite the package from scratch. Seeing as this source code is now outdated, I have added a deprecation notice in an attempt to redirect users to my repository.

Your efforts to maintain the package up to this point are much appreciated. Please let me know if you'd like to remain on as a co-maintainer. If so, I can give you collaborator access on the new repository.